### PR TITLE
Fix leftover brand name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "wall-masters",
+  "name": "poo-patrol",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "wall-masters",
+      "name": "poo-patrol",
       "version": "0.0.0",
       "dependencies": {
         "@chakra-ui/icons": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "wall-masters",
+  "name": "poo-patrol",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/src/assets/i18n.ts
+++ b/src/assets/i18n.ts
@@ -190,7 +190,7 @@ i18n
             orderDetails: "Order Details",
             errorPlacingOrder: "There was an error placing your order. Please try again.",
             successPlacingOrder: "Order placed successfully!",
-            companyName: "Wall Masters",
+            companyName: "Poo Patrol",
             copyright: "© {{year}} COCO. All rights reserved.",
             contactInfo: "For Contact Call: 01222204651",
      


### PR DESCRIPTION
## Summary
- update old company name to `Poo Patrol`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_6849a1ff08f48325a79af3288a472ffd